### PR TITLE
Use default sender

### DIFF
--- a/src/SmscRuApi.php
+++ b/src/SmscRuApi.php
@@ -54,7 +54,7 @@ class SmscRuApi
             'fmt'     => self::FORMAT_JSON,
         ];
 
-        $params = array_merge($base, $params);
+        $params = array_merge($params, $base);
 
         try {
             $response = $this->httpClient->post($this->apiUrl, ['form_params' => $params]);


### PR DESCRIPTION
If sending message without calling `->from` method, use `sender` from base service configuration.