### PR TITLE
routeNotificationForSmscru() may return zero or many phones

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ class AccountApproved extends Notification
 }
 ```
 
-In your notifiable model, make sure to include a routeNotificationForSmscru() method, which return the phone number.
+In your notifiable model, make sure to include a `routeNotificationForSmscru()` method, which returns a phone number
+or an array of phone numbers.
 
 ```php
 public function routeNotificationForSmscru()

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -11,6 +11,7 @@ class CouldNotSendNotification extends Exception
      * Thrown when recipient's phone number is missing.
      *
      * @return static
+     * @deprecated Not used anymore and will be removed in the next major release
      */
     public static function missingRecipient()
     {

--- a/tests/SmscRuChannelTest.php
+++ b/tests/SmscRuChannelTest.php
@@ -3,11 +3,11 @@
 namespace NotificationChannel\SmscRu\Tests;
 
 use Mockery as M;
+use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\SmscRu\SmscRuApi;
 use NotificationChannels\SmscRu\SmscRuChannel;
 use NotificationChannels\SmscRu\SmscRuMessage;
-use NotificationChannels\SmscRu\Exceptions\CouldNotSendNotification;
 
 class SmscRuChannelTest extends \PHPUnit_Framework_TestCase
 {
@@ -87,17 +87,36 @@ class SmscRuChannelTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_does_not_send_a_message_when_to_missed()
     {
-        $this->expectException(CouldNotSendNotification::class);
+        $this->smsc->shouldNotReceive('send');
 
         $this->channel->send(
             new TestNotifiableWithoutRouteNotificationForSmscru(), new TestNotification()
         );
     }
+
+    /** @test */
+    public function it_can_send_a_notification_to_multiple_phones()
+    {
+        $this->smsc->shouldReceive('send')->once()
+            ->with(
+                [
+                    'phones'  => '+1234567890,+0987654321,+1234554321',
+                    'mes'     => 'hello',
+                    'sender'  => 'John_Doe',
+                ]
+            );
+
+        $this->channel->send(new TestNotifiableWithManyPhones(), new TestNotification());
+    }
 }
 
 class TestNotifiable
 {
-    public function routeNotificationFor()
+    use Notifiable;
+
+    // Laravel v5.6+ passes the notification instance here
+    // So we need to add `Notification $notification` argument to check it when this project stops supporting < 5.6
+    public function routeNotificationForSmscru()
     {
         return '+1234567890';
     }
@@ -105,9 +124,17 @@ class TestNotifiable
 
 class TestNotifiableWithoutRouteNotificationForSmscru extends TestNotifiable
 {
-    public function routeNotificationFor()
+    public function routeNotificationForSmscru()
     {
         return false;
+    }
+}
+
+class TestNotifiableWithManyPhones extends TestNotifiable
+{
+    public function routeNotificationForSmscru()
+    {
+        return ['+1234567890', '+0987654321', '+1234554321'];
     }
 }
 


### PR DESCRIPTION
* If `routeNotificationForSmscru` returns `null`, `false`, an empty string or an empty array, no exception is thrown and the channel just does nothing.
* If `routeNotificationForSmscru` returns an array, the phones (array values) are concatenated with comma and the notification is sent to the phones. 
* The notification instance is passed to `routeNotificationForSmscru()` in Laravel v5.6+.

Resolves #26

I haven't removed the `CouldNotSendNotification::missingRecipient()` method not to make a breaking change. I've marked it as deprecated in the PHPDoc block in the code.